### PR TITLE
Fix Joint State Broadcaster dependency

### DIFF
--- a/tr1200_control/package.xml
+++ b/tr1200_control/package.xml
@@ -11,7 +11,7 @@
 
   <depend>controller_manager</depend>
   <depend>diff_drive_controller</depend>
-  <depend>joint_state_publisher</depend>
+  <depend>joint_state_broadcaster</depend>
   <depend>launch_ros</depend>
   <depend>launch</depend>
   <depend>tr1200_base</depend>


### PR DESCRIPTION
This PR changes the incorrect joint_state_publisher tr1200_control dependency to the corrent package, joint_state_broadcaster.