### PR TITLE
Remove ament_python dependency from tr1200_modules

### DIFF
--- a/tr1200_modules/package.xml
+++ b/tr1200_modules/package.xml
@@ -7,8 +7,6 @@
   <maintainer email="trsupport@trossenrobotics.com">Trossen Robotics</maintainer>
   <license>BSD-3-Clause</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>


### PR DESCRIPTION
This PR removes the nonexistent ament_python dependency from tr1200_modules.