### PR TITLE
Add missing dependencies to tr1200_base manifest

### DIFF
--- a/tr1200_base/package.xml
+++ b/tr1200_base/package.xml
@@ -9,6 +9,11 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>hardware_interface</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
This PR adds dependencies to the tr1200_base package manifest.