### PR TITLE
Add xacro to depends

### DIFF
--- a/tr1200_description/package.xml
+++ b/tr1200_description/package.xml
@@ -13,6 +13,7 @@
   <depend>joint_state_publisher</depend>
   <depend>robot_state_publisher</depend>
   <depend>tr1200_modules</depend>
+  <depend>xacro</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/tr1200_modules/package.xml
+++ b/tr1200_modules/package.xml
@@ -7,6 +7,8 @@
   <maintainer email="trsupport@trossenrobotics.com">Trossen Robotics</maintainer>
   <license>BSD-3-Clause</license>
 
+  <depend>xacro</depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>


### PR DESCRIPTION
This PR adds the `xacro` package dependency to the modules and descriptions package manifests.